### PR TITLE
chore: update issue period to correct value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/src/mappings/_utils.ts
+++ b/src/mappings/_utils.ts
@@ -16,7 +16,7 @@ import { encodeVaultId } from "./encoding";
 
 const debug = Debug("interbtc-mappings:_utils");
 
-const issuePeriod = 14400; // TODO: HARDCODED - fetch from chain once event is implemented
+const issuePeriod = 7200; // TODO: HARDCODED - fetch from chain once event is implemented
 const parachainBlocksPerBitcoinBlock = 100; // TODO: HARDCODED - find better way to set?
 const btcPeriod = Math.ceil(issuePeriod / parachainBlocksPerBitcoinBlock);
 


### PR DESCRIPTION
We should look into fetching these values from the chain somehow in the future (e.g. grabbing directly on first run, then ensure there are events whenever any of them get updated?) but for now this fixes it for Kintsugi