### PR TITLE
feat: asLatest event decoding for mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/src/mappings/event/btcRelay.ts
+++ b/src/mappings/event/btcRelay.ts
@@ -11,7 +11,7 @@ export async function storeMainChainHeader(
     const rawEvent = new BtcRelayStoreMainChainHeaderEvent(ctx);
     let e;
     if (rawEvent.isV4) e = rawEvent.asV4;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const relayedAtHeight = await blockToHeight(
         ctx.store,

--- a/src/mappings/event/issue.ts
+++ b/src/mappings/event/issue.ts
@@ -31,7 +31,7 @@ export async function requestIssue(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const vaultId = await getVaultId(ctx.store, e.vaultId);
     if (vaultId === undefined) {
@@ -97,7 +97,7 @@ export async function executeIssue(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const id = toHex(e.issueId);
 
@@ -142,7 +142,7 @@ export async function cancelIssue(ctx: EventHandlerContext): Promise<void> {
     const rawEvent = new IssueCancelIssueEvent(ctx);
     let e;
     if (rawEvent.isV4) e = rawEvent.asV4;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const issue = await ctx.store.get(Issue, {
         where: { id: toHex(e.issueId) },
@@ -177,7 +177,7 @@ export async function requestRefund(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const id = toHex(e.refundId);
     const issue = await ctx.store.get(Issue, {
@@ -216,7 +216,7 @@ export async function executeRefund(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const refund = await ctx.store.get(Refund, {
         where: { id: toHex(e.refundId) },
@@ -251,7 +251,7 @@ export async function issuePeriodChange(ctx: EventHandlerContext): Promise<void>
     const rawEvent = new IssueIssuePeriodChangeEvent(ctx);
     let e;
     if (rawEvent.isV16) e = rawEvent.asV16;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const height = await blockToHeight(
         ctx.store,

--- a/src/mappings/event/oracle.ts
+++ b/src/mappings/event/oracle.ts
@@ -10,7 +10,7 @@ export async function feedValues(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
     for (const [key, value] of e.values) {
         const height = await blockToHeight(
             ctx.store,

--- a/src/mappings/event/redeem.ts
+++ b/src/mappings/event/redeem.ts
@@ -28,7 +28,7 @@ export async function requestRedeem(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const vaultId = await getVaultId(ctx.store, e.vaultId);
     if (vaultId === undefined) {
@@ -93,7 +93,7 @@ export async function executeRedeem(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const redeem = await ctx.store.get(Redeem, {
         where: { id: toHex(e.redeemId) },
@@ -135,7 +135,7 @@ export async function cancelRedeem(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const redeem = await ctx.store.get(Redeem, {
         where: { id: toHex(e.redeemId) },
@@ -171,7 +171,7 @@ export async function redeemPeriodChange(ctx: EventHandlerContext): Promise<void
     const rawEvent = new RedeemRedeemPeriodChangeEvent(ctx);
     let e;
     if (rawEvent.isV16) e = rawEvent.asV16;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const height = await blockToHeight(
         ctx.store,

--- a/src/mappings/event/security.ts
+++ b/src/mappings/event/security.ts
@@ -6,7 +6,7 @@ export async function updateActiveBlock(ctx: EventHandlerContext): Promise<void>
     const rawEvent = new SecurityUpdateActiveBlockEvent(ctx);
     let e;
     if (rawEvent.isV4) e = rawEvent.asV4;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const newHeight = new Height({
         id: ctx.block.height.toString(),

--- a/src/mappings/event/vault.ts
+++ b/src/mappings/event/vault.ts
@@ -18,7 +18,7 @@ export async function registerVault(ctx: EventHandlerContext): Promise<void> {
     if (rawEvent.isV6) e = rawEvent.asV6;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const registrationBlock = await blockToHeight(
         ctx.store,
@@ -47,7 +47,7 @@ export async function increaseLockedCollateral(
     if (rawEvent.isV10) e = rawEvent.asV10;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
     const collateralToken = currencyId.token.encode(e.currencyPair.collateral);
     const wrappedToken = currencyId.token.encode(e.currencyPair.wrapped);
 
@@ -71,7 +71,7 @@ export async function decreaseLockedCollateral(
     if (rawEvent.isV10) e = rawEvent.asV10;
     else if (rawEvent.isV15) e = rawEvent.asV15;
     else if (rawEvent.isV17) e = rawEvent.asV17;
-    else throw Error("Unknown event version");
+    else e = rawEvent.asLatest;
 
     const collateralToken = currencyId.token.encode(e.currencyPair.collateral);
     const wrappedToken = currencyId.token.encode(e.currencyPair.wrapped);


### PR DESCRIPTION
Adding asLatest decoding of events for the mainnet instead of throwing `Unknown event version` error.