### PR TITLE
fix: fix cumulative volume calculations that were broken in 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",


### PR DESCRIPTION
 - The addition for total (currency-agnostic) volumes was broken; fixed
 - Additionally, simplified the handling of the case where two events happen in the same block (and an earlier entity has to be updated, since cumulative volumes are keyed on timestamp, i.e. block)
 - Additionally, added missing handling for the above to the currency-specific volumes; this hasn't come up yet but could have theoretically have caused a crash in the right conditions (e.g. two issue requests being executed in the same block)