### PR TITLE
Fix: Set initial redeem period when no existing one can be found

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,18 @@ services:
       POSTGRES_PASSWORD: ${DB_PASS}
       POSTGRES_DB: ${DB_NAME}
 
+  db-kintsugi-testnet:
+    image: postgres:12
+    restart: always
+    ports:
+      - "5433:5432"
+    volumes:
+      - /var/lib/postgresql/data2
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_DB: ${DB_NAME}
+
   db-interlay-temp:
     image: postgres:12
     restart: always

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/src/mappings/utils/requestPeriods.ts
+++ b/src/mappings/utils/requestPeriods.ts
@@ -32,7 +32,7 @@ export async function getCurrentIssuePeriod(
 
 export async function getCurrentRedeemPeriod(ctx: Ctx, block: SubstrateBlock) {
     const height = await blockToHeight(ctx, block.height);
-    const latest = getLatestStoredRedeemPeriod(ctx, block.height);
+    const latest = await getLatestStoredRedeemPeriod(ctx, block.height);
     if (latest !== undefined) return latest;
 
     // else fetch from storage


### PR DESCRIPTION
Add missing `await` statement, so the following check for `undefined` actually leads to setting an initial redeem period if no existing one is found.

Previous bug would lead to errors downstream where requests may be missing periods, and with no global period set, it could produce broken SQL insert statements.