### PR TITLE
Fix: handle broken v6 token transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",


### PR DESCRIPTION
Added logic to be able to deal with older token transfer events and modified checks to keep squid from stopping at runtime when no handling was implemented for a specific, unknown version of token.transfer (will log the problem, though).