### PR TITLE
Fix: use in memory entities for cumulative counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/src/mappings/event/escrow.ts
+++ b/src/mappings/event/escrow.ts
@@ -27,7 +27,7 @@ export async function deposit(
             VolumeType.Staked,
             e.amount,
             timestamp,
-            item
+            entityBuffer
         )
     );
 }
@@ -53,7 +53,7 @@ export async function withdraw(
             VolumeType.Staked,
             -e.amount,
             timestamp,
-            item
+            entityBuffer
         )
     );
 }

--- a/src/mappings/event/issue.ts
+++ b/src/mappings/event/issue.ts
@@ -168,7 +168,7 @@ export async function executeIssue(
             VolumeType.Issued,
             amountWrapped,
             new Date(block.timestamp),
-            item
+            entityBuffer
         )
     );
     await entityBuffer.pushEntity(
@@ -178,9 +178,9 @@ export async function executeIssue(
             VolumeType.Issued,
             amountWrapped,
             new Date(block.timestamp),
-            item,
             collateralCurrency,
-            wrappedCurrency
+            wrappedCurrency,
+            entityBuffer
         )
     );
 }

--- a/src/mappings/event/redeem.ts
+++ b/src/mappings/event/redeem.ts
@@ -164,7 +164,7 @@ export async function executeRedeem(
             VolumeType.Redeemed,
             redeem.request.requestedAmountBacking,
             new Date(block.timestamp),
-            item
+            entityBuffer
         )
     );
     await entityBuffer.pushEntity(
@@ -174,9 +174,9 @@ export async function executeRedeem(
             VolumeType.Redeemed,
             redeem.request.requestedAmountBacking,
             new Date(block.timestamp),
-            item,
             collateralCurrency,
-            wrappedCurrency
+            wrappedCurrency,
+            entityBuffer
         )
     );
 }

--- a/src/mappings/utils/entityBuffer.ts
+++ b/src/mappings/utils/entityBuffer.ts
@@ -1,19 +1,39 @@
 import { Entity, Store } from "@subsquid/typeorm-store";
 
 export default class EntityBuffer {
-    buffer = new Map<String, Entity[]>();
+    // type - id - entity
+    buffer = new Map<String, Map<String, Entity>>();
 
-    async pushEntity(key: string, entity: Entity) {
-        if (!this.buffer.has(key)) {
-            this.buffer.set(key, []);
+    async pushEntity(type: string, entity: Entity) {
+        if (!this.buffer.has(type)) {
+            this.buffer.set(type, new Map([[entity.id, entity]]));
+            return;
         }
-        this.buffer.get(key)!.push(entity);
+        this.buffer.get(type)!.set(entity.id, entity);
     }
 
     async flush(store: Store) {
-        for (const [, entities] of this.buffer) {
+        // not allowed to mix entities of different types for saving in bulk
+        for (const [, nestedMap] of this.buffer) {
+            const entities = [...nestedMap.values()];
+
             await store.save(entities);
         }
+
         this.buffer.clear();
     }
-};
+
+    getBufferedEntities(type: string): Entity[] {
+        if (this.buffer.get(type) === undefined) {
+            return [];
+        }
+
+        return Array.from(this.buffer.get(type)!.values());
+    }
+
+    getBufferedEntityBy(type: string, id: string): Entity | undefined {
+        return this.getBufferedEntities(type).find(
+            (entity) => entity.id === id
+        );
+    }
+}


### PR DESCRIPTION
Fixing a few issues introduced in our squid with the upgrade to firesquid's batch processing of events:
- Cumulative values were incorrect as values from events were added to the last known value in the database, but newer entities with increased values would sit in the entity buffer to be saved. This fix checks entity buffers for the latest values too.
- A previous change to entity ids for cumulative entities led to multiple database entries per block. This could lead to further issues in finding the correct latest accumulated value to increase. Changed the id generation closer to what it was before where duplications were avoided.
- Changed structure of entity buffer to a double map so it is easier to replace entities by their respective ids.