### PR TITLE
Fix: add lend token as possible pooled token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/schema.graphql
+++ b/schema.graphql
@@ -45,7 +45,7 @@ type StableLpToken {
     poolId: Int!
 }
 
-union PooledToken = NativeToken | ForeignAsset | StableLpToken
+union PooledToken = NativeToken | ForeignAsset | StableLpToken | LendToken
 
 type LpToken {
     token0: PooledToken!

--- a/src/mappings/event/dex.ts
+++ b/src/mappings/event/dex.ts
@@ -103,7 +103,7 @@ function createSwapDetailsAmounts(
         if (!isPooledToken(currency)) {
             throw new Error(`Cannot create SwapDetailsAmounts; unexpected currency type found (${
                 currency.isTypeOf
-            }`);
+            })`);
         }
 
         amounts.push({

--- a/src/model/generated/_pooledToken.ts
+++ b/src/model/generated/_pooledToken.ts
@@ -1,14 +1,16 @@
 import {NativeToken} from "./_nativeToken"
 import {ForeignAsset} from "./_foreignAsset"
 import {StableLpToken} from "./_stableLpToken"
+import {LendToken} from "./_lendToken"
 
-export type PooledToken = NativeToken | ForeignAsset | StableLpToken
+export type PooledToken = NativeToken | ForeignAsset | StableLpToken | LendToken
 
 export function fromJsonPooledToken(json: any): PooledToken {
     switch(json?.isTypeOf) {
         case 'NativeToken': return new NativeToken(undefined, json)
         case 'ForeignAsset': return new ForeignAsset(undefined, json)
         case 'StableLpToken': return new StableLpToken(undefined, json)
+        case 'LendToken': return new LendToken(undefined, json)
         default: throw new TypeError('Unknown json object passed as PooledToken')
     }
 }


### PR DESCRIPTION
DexStable pools can contain `LendToken` in their pools (whereas DexGeneral pools don't).
Therefore, extend the `PooledToken` definition to allow for `LendToken`.