### PR TITLE
Fix: Div by zero error in getExchangeRate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/src/mappings/_utils.ts
+++ b/src/mappings/_utils.ts
@@ -210,7 +210,7 @@ function mapCurrencyType(currency: Currency): CurrencyType {
                     return Polkadot;
                 case 'KBTC':
                     return KBtc;
-                case 'INTR':
+                case 'IBTC':
                     return InterBtc;
             }
         case 'ForeignAsset':
@@ -292,12 +292,19 @@ export async function getExchangeRate(
     // there are 8 digits in BTC
     const btcMonetaryAmount = newMonetaryAmount(btcPrice, Bitcoin);
 
-    const exchangeRate = btcMonetaryAmount.toBig().div(baseMonetaryAmount.toBig());
+    const baseAmt = baseMonetaryAmount.toBig();
+    const exchangeRate = baseAmt.eq(0)
+        ? Big(0)
+        : btcMonetaryAmount.toBig().div(baseAmt);
     const monetaryAmount = newMonetaryAmount(Big(amount), mappedCurrency);
 
     return {
-        btc: monetaryAmount.toBig().div(baseMonetaryAmount.toBig()), 
-        usdt: monetaryAmount.toBig().mul(exchangeRate)
+        btc: baseAmt.eq(0)
+            ? Big(0)
+            : monetaryAmount.toBig().div(baseAmt),
+        usdt: exchangeRate.eq(0)
+            ? Big(0)
+            : monetaryAmount.toBig().mul(exchangeRate)
     };
 }
 

--- a/src/mappings/_utils.ts
+++ b/src/mappings/_utils.ts
@@ -302,9 +302,7 @@ export async function getExchangeRate(
         btc: baseAmt.eq(0)
             ? Big(0)
             : monetaryAmount.toBig().div(baseAmt),
-        usdt: exchangeRate.eq(0)
-            ? Big(0)
-            : monetaryAmount.toBig().mul(exchangeRate)
+        usdt: monetaryAmount.toBig().mul(exchangeRate)
     };
 }
 


### PR DESCRIPTION
Fixing two issues:
1) Bug in code where it should identify IBTC as Bitcoin priced (looks like copy pasta error)
2) Avoid div by zero errors when converting, rather return 0.