### PR TITLE
Feat: Add test coverage action

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,3 +13,4 @@ jobs:
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           package-manager: yarn
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,8 @@
 name: 'coverage'
 permissions:
   pull-requests: write
+  checks: write
+  contents: write
 on:
   pull_request:
     branches:
@@ -14,9 +16,8 @@ jobs:
       - uses: ArtiomTr/jest-coverage-report-action@v2
         id: coverage
         with:
-          test-script: yarn jest --passWithNoTests
-          package-manager: yarn
           output: report-markdown
+          package-manager: yarn
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           # comment output from coverage

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,7 +1,11 @@
 name: 'coverage'
+permissions:
+  pull-requests: write
+  checks: write
+  contents: write
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,23 @@
+name: 'coverage'
+permissions:
+  pull-requests: write
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        id: coverage
+        with:
+          test-script: yarn jest --passWithNoTests
+          package-manager: yarn
+          output: report-markdown
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # comment output from coverage
+          message: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,24 +1,15 @@
 name: 'coverage'
-permissions:
-  pull-requests: write
-  checks: write
-  contents: write
+
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
-      - main
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ArtiomTr/jest-coverage-report-action@v2
-        id: coverage
         with:
-          output: report-markdown
           package-manager: yarn
-      - uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          # comment output from coverage
-          message: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,11 +1,7 @@
 name: 'coverage'
-permissions:
-  pull-requests: write
-  checks: write
-  contents: write
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
Resolves #133  

Continuation of PR #131 - add workflow action now that the comparison branch has jest available.

- [x] Add workflow to generate coverage report
- [x] Modify action to add comment to PR with coverage results
(Edit: should work? Only visible after merge I think? Permissions for PRs from forks don't include write access)