### PR TITLE
Chore: Replace new instances of ApiPromises with (re)using interBtcApi instance

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,9 @@
 name: 'coverage'
 
 on:
+  push:
+    branches:
+      - master
   pull_request_target:
     branches:
       - master

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "jest" :{
         "preset": "ts-jest",
         "testEnvironment": "node",
+        "modulePathIgnorePatterns": [
+            "<rootDir>/lib/"
+        ],
         "collectCoverageFrom": [
             "<rootDir>/src/**/*.ts*"
         ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.16.5",
+    "version": "0.16.6",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/src/mappings/_utils.test.ts
+++ b/src/mappings/_utils.test.ts
@@ -33,7 +33,7 @@ describe("_utils", () => {
         },
         name: "FooCoin",
         ticker:"FOO",
-        decimals: 42
+        decimals: 7
     };
 
     afterAll(() => {
@@ -116,8 +116,8 @@ describe("_utils", () => {
     
             expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
             expect(libGetForeignAssetsMock).toHaveBeenCalledTimes(1);
-            expect(actualCache.has(42)).toBe(true);
-            expect(actualCache.get(42)).toBe(fakeAssets[0]);
+            expect(actualCache.has(fakeAsset.foreignAsset.id)).toBe(true);
+            expect(actualCache.get(fakeAsset.foreignAsset.id)).toBe(fakeAsset);
         });
 
         it("should reject if getInterBtcApi rejects", async () => {

--- a/src/mappings/_utils.test.ts
+++ b/src/mappings/_utils.test.ts
@@ -1,5 +1,6 @@
 import { ForeignAsset as LibForeignAsset } from "@interlay/interbtc-api";
-import { cacheForeignAssets, getForeignAsset, testHelpers } from "./_utils";
+import { cacheForeignAssets, getForeignAsset, symbolFromCurrency, testHelpers } from "./_utils";
+import { ForeignAsset, NativeToken, Token } from "../model";
 
 // mocking getForeignAsset and getForeignAssets in the lib (interBtcApi)
 const libGetForeignAssetsMock = jest.fn();
@@ -177,5 +178,34 @@ describe("_utils", () => {
             const newUsdtAssetId = testHelpers.getUsdtAssetId();
             expect(newUsdtAssetId).toBe(oldUsdtAssetId);
         });
+    });
+
+    describe("symbolFromCurrency", () => {
+        it("should return token name for native token", async () => {
+            const testNativeToken = new NativeToken({token: Token.KINT});
+            const actualSymbol = await symbolFromCurrency(testNativeToken);
+
+            expect(actualSymbol).toBe(Token.KINT);
+        });
+
+        it("should return ticker for foreign asset", async () => {
+            const testAssetId = fakeAsset.foreignAsset.id;
+            // prepare cache for lookup
+            testHelpers.getForeignAssetsCache().set(testAssetId, fakeAsset);
+            
+            const testForeignAsset = new ForeignAsset({asset: testAssetId});
+            const actualSymbol = await symbolFromCurrency(testForeignAsset);
+            expect(actualSymbol).toBe(fakeAsset.ticker);
+        });
+
+        it("should return unknown for unhandled currency type", async () => {
+            const badTestCurrency = {
+                isTypeOf: "definitely not a valid type"
+            };
+
+            const actualSymbol = await symbolFromCurrency(badTestCurrency as any);
+            expect(actualSymbol).toBe("UNKNOWN");
+        });
+
     });
 });

--- a/src/mappings/_utils.test.ts
+++ b/src/mappings/_utils.test.ts
@@ -1,0 +1,139 @@
+import { ForeignAsset as LibForeignAsset } from "@interlay/interbtc-api";
+import { cacheForeignAssets, getForeignAsset, getForeignAssetsCache } from "./_utils";
+
+// mocking getForeignAsset and getForeignAssets in the lib (interBtcApi)
+const libGetForeignAssetsMock = jest.fn();
+const libGetForeignAssetMock = jest.fn();
+const mockInterBtcApi = {
+    assetRegistry: {
+        getForeignAssets: () => libGetForeignAssetsMock(),
+        getForeignAsset: (id: number) => libGetForeignAssetMock(id)
+    }
+};
+
+// "default" good result mock implementation, should be set inside tests, too (will be reset between tests)
+const getInterBtcApiMock = jest.fn().mockImplementation(() => Promise.resolve(mockInterBtcApi));
+jest.mock("./utils/interBtcApi", () => {
+    const originalModule = jest.requireActual("./utils/interBtcApi");
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        getInterBtcApi: () => getInterBtcApiMock()
+    }
+});
+
+describe("_utils", () => {
+    // fake asset to play with
+    const fakeAsset = {
+        foreignAsset: {
+            id: 42,
+            coingeckoId: "foo"
+        },
+        name: "FooCoin",
+        ticker:"FOO",
+        decimals: 42
+    };
+
+    afterAll(() => {
+        jest.resetAllMocks();
+    });
+
+    describe("getForeignAsset", () => {
+        beforeEach(() => {
+            // clean out cache
+            getForeignAssetsCache().clear();
+        });
+
+        afterEach(() => {
+            libGetForeignAssetMock.mockReset();
+            getInterBtcApiMock.mockReset();
+        });
+
+        it("should fetch value from cache first", async () => {
+            libGetForeignAssetMock.mockImplementation(() => Promise.resolve(fakeAsset));
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+
+            // relies on cache to have been passed as reference
+            getForeignAssetsCache().set(fakeAsset.foreignAsset.id, fakeAsset);
+
+            const actualAsset = await getForeignAsset(fakeAsset.foreignAsset.id);
+            expect(actualAsset).toBe(fakeAsset);
+            expect(getInterBtcApiMock).not.toHaveBeenCalled();
+            expect(libGetForeignAssetMock).not.toHaveBeenCalled();
+        });
+
+        it("should fetch from lib and add to cache", async () => {
+            libGetForeignAssetMock.mockImplementation(() => Promise.resolve(fakeAsset));
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+
+            // clean out cache
+            getForeignAssetsCache().clear();
+
+            const actualAsset = await getForeignAsset(fakeAsset.foreignAsset.id);
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetForeignAssetMock).toHaveBeenCalledTimes(1);
+
+            expect(actualAsset).toBe(fakeAsset);
+
+            const cacheNow = getForeignAssetsCache();
+            expect(cacheNow.size).toBe(1);
+            expect(cacheNow.has(fakeAsset.foreignAsset.id)).toBe(true);
+        });
+
+        it("should reject if getInterBtcApi rejects", async () => {
+            getInterBtcApiMock.mockImplementation(() => Promise.reject(Error("soz lol")));
+
+            await expect(getForeignAsset(fakeAsset.foreignAsset.id)).rejects.toThrow("soz lol");
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetForeignAssetMock).not.toHaveBeenCalled();
+        });
+
+        it("should reject if assetRegistry.getForeignAssets rejects", async () => {
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+            libGetForeignAssetMock.mockImplementation(() => Promise.reject(Error("computer says no")));
+
+            await expect(getForeignAsset(fakeAsset.foreignAsset.id)).rejects.toThrow("computer says no");
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetForeignAssetMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("cacheForeignAssets", () => {
+        afterEach(() => {
+            libGetForeignAssetsMock.mockReset();
+            getInterBtcApiMock.mockReset();
+        });
+
+        it("should get all foreign assets from lib as expected", async () => {
+            const fakeAssets = [fakeAsset];
+            libGetForeignAssetsMock.mockImplementation(() => Promise.resolve(fakeAssets));
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+    
+            await cacheForeignAssets();
+            const actualCache = getForeignAssetsCache();
+    
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetForeignAssetsMock).toHaveBeenCalledTimes(1);
+            expect(actualCache.has(42)).toBe(true);
+            expect(actualCache.get(42)).toBe(fakeAssets[0]);
+        });
+
+        it("should reject if getInterBtcApi rejects", async () => {
+            getInterBtcApiMock.mockImplementation(() => Promise.reject(Error("nope")));
+
+            await expect(cacheForeignAssets()).rejects.toThrow("nope");
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetForeignAssetsMock).not.toHaveBeenCalled();
+        });
+
+        it("should reject if assetRegistry.getForeignAssets rejects", async () => {
+            libGetForeignAssetsMock.mockImplementation(() => Promise.reject(Error("no assets for you")));
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+
+            await expect(cacheForeignAssets()).rejects.toThrow("no assets for you");
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetForeignAssetsMock).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/mappings/_utils.ts
+++ b/src/mappings/_utils.ts
@@ -105,10 +105,13 @@ export async function getForeignAsset(id: number): Promise<LibForeignAsset> {
     return asset;
 }
 
-// getter for easier testing
-export function getForeignAssetsCache() {
-    return cache;
-}
+/**
+ * Helper methods to facilitate testing, use at own risk
+ */
+export const testHelpers = {
+    getForeignAssetsCache: () => cache,
+    getUsdtAssetId: () => usdtAssetId
+};
 
 /* This function takes a currency object (could be native, could be foreign) and
 an amount (in the smallest unit, e.g. Planck) and returns a human friendly string

--- a/src/mappings/_utils.ts
+++ b/src/mappings/_utils.ts
@@ -1,17 +1,18 @@
 import { CurrencyExt, CurrencyIdentifier, currencyIdToMonetaryCurrency, FIXEDI128_SCALING_FACTOR, newCollateralBTCExchangeRate, newMonetaryAmount, StandardPooledTokenIdentifier } from "@interlay/interbtc-api";
-import { Bitcoin, ExchangeRate, InterBtc, Interlay, KBtc, Kintsugi, Kusama, Polkadot } from "@interlay/monetary-js";
-import { ApiPromise, WsProvider } from '@polkadot/api';
+import { Bitcoin, ExchangeRate } from "@interlay/monetary-js";
 import { BigDecimal } from "@subsquid/big-decimal";
 import { Store } from "@subsquid/typeorm-store";
 import { Big, BigSource } from "big.js";
 import * as process from "process";
 import { LessThanOrEqual, Like } from "typeorm";
 import { Currency, ForeignAsset, Height, Issue, OracleUpdate, OracleUpdateType, Redeem, Token, Vault } from "../model";
-import { Ctx, getInterBtcApi } from "../processor";
+import { Ctx } from "../processor";
+import { getInterBtcApi } from "./utils/interBtcApi";
 import { VaultId as VaultIdV1021000 } from "../types/v1021000";
 import { VaultId as VaultIdV15 } from "../types/v15";
 import { VaultId as VaultIdV6 } from "../types/v6";
 import { encodeLegacyVaultId, encodeVaultId } from "./encoding";
+import { ForeignAsset as LibForeignAsset } from "@interlay/interbtc-api";
 
 export type eventArgs = {
     event: { args: true };
@@ -73,46 +74,40 @@ type AssetMetadata = {
     symbol: string;
 }
 
-// This function uses the storage API to obtain the details directly from the
-// WSS RPC provider for the correct chain
-const cache: { [id: number]: AssetMetadata } = {};
+// simple cache for foreign assets by id
+const cache: Map<number, LibForeignAsset> = new Map();
 let usdtAssetId: number;
 
-export async function cacheForeignAsset(): Promise<void> {
-    try {
-        const wsProvider = new WsProvider(process.env.CHAIN_ENDPOINT);
-        const api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
-        const assets = await api.query.assetRegistry.metadata.entries();
-        assets.forEach(([key, details]) => {
-            const id:number = Number(key.args[0]);
-            const assetDetails = details.toHuman() as AssetMetadata;
-            cache[id] = assetDetails;
-            if(assetDetails.symbol==='USDT') usdtAssetId = id;
-          });        
-    } catch (error) {
-        console.error(`Error getting foreign asset metadata: ${error}`);
-        throw error;
-    }
+export async function cacheForeignAssets(): Promise<void> {
+    const interBtcApi = await getInterBtcApi();
+    const foreignAssets = await interBtcApi.assetRegistry.getForeignAssets();
+    foreignAssets.forEach((asset) => {
+        const id = asset.foreignAsset.id;
+
+        cache.set(id, asset);
+
+        if(asset.ticker === 'USDT') {
+            usdtAssetId = id;
+        } 
+    });
 }
 
+export async function getForeignAsset(id: number): Promise<LibForeignAsset> {
+    if (cache.has(id)) {
+        return cache.get(id)!;
+    }
 
-export async function getForeignAsset(id: number): Promise<AssetMetadata> {
-    if (id in cache) {
-        return cache[id];
-    }
-    try {
-        const wsProvider = new WsProvider(process.env.CHAIN_ENDPOINT);
-        const api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
-        const assets = await api.query.assetRegistry.metadata(id);
-        const assetsJSON = assets.toHuman();
-        const metadata = assetsJSON as AssetMetadata;
-        console.debug(`Foreign Asset (${id}): ${JSON.stringify(metadata)}`);
-        cache[id] = metadata;
-        return metadata;
-    } catch (error) {
-        console.error(`Error getting foreign asset metadata: ${error}`);
-        throw error;
-    }
+    const interBtcApi = await getInterBtcApi();
+    const asset = await interBtcApi.assetRegistry.getForeignAsset(id);
+
+    cache.set(id,asset);
+    
+    return asset;
+}
+
+// getter for easier testing
+export function getForeignAssetsCache() {
+    return cache;
 }
 
 /* This function takes a currency object (could be native, could be foreign) and
@@ -155,13 +150,12 @@ export function divideByTenToTheNth(amount: bigint, n: number): number {
 }
 
 export async function symbolFromCurrency(currency: Currency): Promise<string> {
-    let amountFriendly: number;
     switch(currency.isTypeOf) {
         case 'NativeToken':
             return currency.token;
         case 'ForeignAsset':
             const details = await getForeignAsset(currency.asset)
-            return details.symbol;
+            return details.ticker;
         default:
             return `UNKNOWN`;
     }

--- a/src/mappings/utils/interBtcApi.test.ts
+++ b/src/mappings/utils/interBtcApi.test.ts
@@ -1,0 +1,73 @@
+import { BitcoinNetwork } from "@interlay/interbtc-api";
+import { getInterBtcApi, testHelpers } from "./interBtcApi";
+
+const createInterBtcApiMock = jest.fn();
+jest.mock("@interlay/interbtc-api", () => {
+    const originalModule = jest.requireActual("@interlay/interbtc-api");
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        createInterBtcApi: (endpoint: string, network: BitcoinNetwork) => createInterBtcApiMock(endpoint, network)
+    }
+});
+
+
+describe("interBtcApi", () => {
+    afterAll(() => {
+        jest.resetAllMocks();
+    });
+
+    describe("getInterBtcApi", () => {
+        const connectedFakeApi = {
+            api: {
+                isConnected: true
+            }
+        };
+
+        const disconnectedFakeApi = {
+            api: {
+                isConnected: false
+            }
+        };
+
+        afterEach(() => {
+            createInterBtcApiMock.mockReset();
+        });
+
+        it("should create a new instance", async () => {
+            createInterBtcApiMock.mockImplementation((_args) => Promise.resolve(connectedFakeApi));
+
+            // reset to undefined
+            testHelpers.unsafeSetInterBtcApi(undefined);
+
+            const actualApi = await getInterBtcApi();
+
+            expect(actualApi).toBe(connectedFakeApi);
+            expect(actualApi.api.isConnected).toBe(true);
+            expect(createInterBtcApiMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("should return connected instance if possible", async () => {
+            testHelpers.unsafeSetInterBtcApi(connectedFakeApi);
+
+            const actualApi = await getInterBtcApi();
+
+            expect(actualApi).toBe(connectedFakeApi);
+            expect(actualApi.api.isConnected).toBe(true);
+            expect(createInterBtcApiMock).not.toHaveBeenCalled();
+        });
+
+        it("should create new instance if existing one is disconnected", async () => {
+            createInterBtcApiMock.mockImplementation((_args) => Promise.resolve(connectedFakeApi));
+
+            testHelpers.unsafeSetInterBtcApi(disconnectedFakeApi);
+
+            const actualApi = await getInterBtcApi();
+
+            expect(actualApi).toBe(connectedFakeApi);
+            expect(actualApi.api.isConnected).toBe(true);
+            expect(createInterBtcApiMock).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/mappings/utils/interBtcApi.ts
+++ b/src/mappings/utils/interBtcApi.ts
@@ -15,7 +15,7 @@ export const getInterBtcApi = async (): Promise<InterBtcApi> => {
 /**
  * Only exported for better testing, use at own risk
  */
-export const testHelpers= { 
+export const testHelpers = { 
     unsafeSetInterBtcApi: (maybeApi: any) => {
         interBtcApi = maybeApi as InterBtcApi | undefined;
     }

--- a/src/mappings/utils/interBtcApi.ts
+++ b/src/mappings/utils/interBtcApi.ts
@@ -1,0 +1,22 @@
+import { BitcoinNetwork, createInterBtcApi, InterBtcApi } from "@interlay/interbtc-api";
+
+let interBtcApi: InterBtcApi | undefined = undefined;
+
+export const getInterBtcApi = async (): Promise<InterBtcApi> => {
+    if (interBtcApi === undefined || !interBtcApi.api.isConnected) {
+        const PARACHAIN_ENDPOINT = process.env.CHAIN_ENDPOINT;
+        const BITCOIN_NETWORK = process.env.BITCOIN_NETWORK as BitcoinNetwork;
+
+        interBtcApi = await createInterBtcApi(PARACHAIN_ENDPOINT!, BITCOIN_NETWORK!);
+    }
+    return interBtcApi;
+};
+
+/**
+ * Only exported for better testing, use at own risk
+ */
+export const testHelpers= { 
+    unsafeSetInterBtcApi: (maybeApi: any) => {
+        interBtcApi = maybeApi as InterBtcApi | undefined;
+    }
+}

--- a/src/mappings/utils/pools.ts
+++ b/src/mappings/utils/pools.ts
@@ -20,27 +20,24 @@ const DEX_GENERAL_FEE_DENOMINATOR: number = 10_000;
 
 // Replicated order from parachain code. 
 // See https://github.com/interlay/interbtc/blob/4cf80ce563825d28d637067a8a63c1d9825be1f4/primitives/src/lib.rs#L492-L498
-const indexToCurrencyTypeMap: Map<number, string> = new Map([
-    [0, "NativeToken"],
-    [1, "ForeignAsset"],
-    [2, "LendToken"],
-    [3, "LpToken"],
-    [4, "StableLpToken"]
+const currencyTypeToIndexMap = new Map([
+    ["NativeToken", 0],
+    ["ForeignAsset", 1],
+    ["LendToken", 2],
+    ["LpToken", 3],
+    ["StableLpToken", 4]
 ]);
-const currencyTypeToIndexMap = invertMap(indexToCurrencyTypeMap);
 
 // Replicated order from parachain code. 
 // See also https://github.com/interlay/interbtc/blob/d48fee47e153291edb92525221545c2f4fa58501/primitives/src/lib.rs#L469-L476
-const indexToNativeTokenMap: Map<number, Token> = new Map([
-    [0, Token.DOT],
-    [1, Token.IBTC],
-    [2, Token.INTR],
-    [10, Token.KSM],
-    [11, Token.KBTC],
-    [12, Token.KINT]
+const nativeTokenToIndexMap: Map<Token, number> = new Map([
+    [Token.DOT, 0],
+    [Token.IBTC, 1],
+    [Token.INTR, 2],
+    [Token.KSM, 10],
+    [Token.KBTC, 11],
+    [Token.KINT, 12]
 ]);
-
-const nativeTokenToIndexMap = invertMap(indexToNativeTokenMap);
 
 // poor man's stable pool id to currencies cache
 const stablePoolCurrenciesCache = new Map<number, [Currency, CurrencyId][]>();

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -50,8 +50,7 @@ import {
 } from "./mappings/event/tokens";
 import * as heights from "./mappings/utils/heights";
 import EntityBuffer from "./mappings/utils/entityBuffer";
-import { eventArgsData, cacheForeignAsset } from "./mappings/_utils";
-import { BitcoinNetwork, createInterBtcApi, InterBtcApi } from "@interlay/interbtc-api";
+import { eventArgsData, cacheForeignAssets } from "./mappings/_utils";
 import { 
     newMarket, 
     updatedMarket, 
@@ -87,7 +86,7 @@ const eventArgsData: eventArgsData = {
 const circulatingSupplyArgs = {...eventArgsData, ...getCirculatingSupplyProcessRange()};
 
 // initialise a cache with all the foreign assets
-cacheForeignAsset();
+cacheForeignAssets();
 
 const processor = new SubstrateBatchProcessor()
     .setDataSource({ archive, chain })
@@ -164,17 +163,6 @@ export type CallItem = Exclude<
 >;
 export type Ctx = BatchContext<Store, Item>;
 
-let interBtcApi: InterBtcApi | undefined = undefined;
-
-export const getInterBtcApi = async () => {
-    if (interBtcApi === undefined) {
-        const PARACHAIN_ENDPOINT = process.env.CHAIN_ENDPOINT;
-        const BITCOIN_NETWORK = process.env.BITCOIN_NETWORK as BitcoinNetwork;
-    
-        interBtcApi = await createInterBtcApi(PARACHAIN_ENDPOINT!, BITCOIN_NETWORK!); 
-    }
-    return interBtcApi;
-}
 processor.run(new TypeormDatabase({ stateSchema: "interbtc" }), async (ctx) => {
     type MappingsList = Array<{
         filter: { name: string };


### PR DESCRIPTION
Resolves #135 

Changes made:
- Removed the creation of new instances of `ApiPromise` when trying to fetch foreign asset data
- Replaced it with using the shared `InterBtcApi` lib instance instead
- Added tests
- Added a few static structures and helpers to assist testing setups
- Simplified a few other structures to remove unnecessary generic map inversions (that confused Jest)
- Edited test coverage action to store base values when merging to master (enables showing change in coverage percentages)