### PR TITLE
Feat: separate pool volumes in & out

### DIFF
--- a/db/migrations/1691727353666-Data.js
+++ b/db/migrations/1691727353666-Data.js
@@ -1,0 +1,21 @@
+module.exports = class Data1691727353666 {
+    name = 'Data1691727353666'
+
+    async up(db) {
+        await db.query(`ALTER TABLE "swap" ADD "pool_type" character varying(8) NOT NULL`)
+        await db.query(`ALTER TABLE "swap" ADD "pool_id" text NOT NULL`)
+        await db.query(`ALTER TABLE "swap" ADD "event_id" text NOT NULL`)
+        await db.query(`CREATE INDEX "IDX_476e1753eb0cbfad230547e79f" ON "swap" ("pool_type") `)
+        await db.query(`CREATE INDEX "IDX_e78e7b899d2e3327494e5fe975" ON "swap" ("pool_id") `)
+        await db.query(`CREATE INDEX "IDX_b1e1c5232ef7fe109be68524b9" ON "swap" ("to_account") `)
+    }
+
+    async down(db) {
+        await db.query(`ALTER TABLE "swap" DROP COLUMN "pool_type"`)
+        await db.query(`ALTER TABLE "swap" DROP COLUMN "pool_id"`)
+        await db.query(`ALTER TABLE "swap" DROP COLUMN "event_id"`)
+        await db.query(`DROP INDEX "public"."IDX_476e1753eb0cbfad230547e79f"`)
+        await db.query(`DROP INDEX "public"."IDX_e78e7b899d2e3327494e5fe975"`)
+        await db.query(`DROP INDEX "public"."IDX_b1e1c5232ef7fe109be68524b9"`)
+    }
+}

--- a/db/migrations/1691727585033-Data.js
+++ b/db/migrations/1691727585033-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1691727353666 {
-    name = 'Data1691727353666'
+module.exports = class Data1691727585033 {
+    name = 'Data1691727585033'
 
     async up(db) {
         await db.query(`ALTER TABLE "swap" ADD "pool_type" character varying(8) NOT NULL`)
@@ -7,6 +7,7 @@ module.exports = class Data1691727353666 {
         await db.query(`ALTER TABLE "swap" ADD "event_id" text NOT NULL`)
         await db.query(`CREATE INDEX "IDX_476e1753eb0cbfad230547e79f" ON "swap" ("pool_type") `)
         await db.query(`CREATE INDEX "IDX_e78e7b899d2e3327494e5fe975" ON "swap" ("pool_id") `)
+        await db.query(`CREATE INDEX "IDX_d1b82e67bf623b7d80b0c9e81e" ON "swap" ("timestamp") `)
         await db.query(`CREATE INDEX "IDX_b1e1c5232ef7fe109be68524b9" ON "swap" ("to_account") `)
     }
 
@@ -16,6 +17,7 @@ module.exports = class Data1691727353666 {
         await db.query(`ALTER TABLE "swap" DROP COLUMN "event_id"`)
         await db.query(`DROP INDEX "public"."IDX_476e1753eb0cbfad230547e79f"`)
         await db.query(`DROP INDEX "public"."IDX_e78e7b899d2e3327494e5fe975"`)
+        await db.query(`DROP INDEX "public"."IDX_d1b82e67bf623b7d80b0c9e81e"`)
         await db.query(`DROP INDEX "public"."IDX_b1e1c5232ef7fe109be68524b9"`)
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interbtc-indexer",
     "private": "true",
-    "version": "0.16.6",
+    "version": "0.16.7",
     "description": "GraphQL server and Substrate indexer for the interBTC parachain",
     "author": "",
     "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "@subsquid/typeorm-migration": "^0.1.4",
         "@subsquid/typeorm-store": "^0.1.5",
         "bitcoinjs-lib": "^5.2.0",
+        "class-validator": "^0.14.0",
         "dotenv": "^10.0.0",
         "lodash": "^4.17.21",
         "pg": "^8.8.0",
@@ -62,7 +63,7 @@
         "singleQuote": false,
         "tabWidth": 4
     },
-    "jest" :{
+    "jest": {
         "preset": "ts-jest",
         "testEnvironment": "node",
         "modulePathIgnorePatterns": [

--- a/schema.graphql
+++ b/schema.graphql
@@ -408,7 +408,7 @@ type Swap @entity {
     poolId: String! @index
     eventId: String!
     height: Height!
-    timestamp: DateTime!
+    timestamp: DateTime! @index
     fromAccount: String! @index
     toAccount: String! @index
     fees: PooledAmount!

--- a/schema.graphql
+++ b/schema.graphql
@@ -404,10 +404,13 @@ type InterestAccrual @entity {
 
 type Swap @entity {
     id: ID!
+    poolType: PoolType! @index
+    poolId: String! @index
+    eventId: String!
     height: Height!
     timestamp: DateTime!
     fromAccount: String! @index
-    toAccount: String!
+    toAccount: String! @index
     fees: PooledAmount!
     feeRate: BigDecimal!
     from: PooledAmount!

--- a/src/mappings/_utils.test.ts
+++ b/src/mappings/_utils.test.ts
@@ -292,8 +292,8 @@ describe("_utils", () => {
             // prepare cache for lookup
             testHelpers.getLendTokensCache().set(testLendTokenId, fakeLendToken);
             
-            const testForeignAsset = new LendToken({lendTokenId: testLendTokenId});
-            const actualSymbol = await tickerFromCurrency(testForeignAsset);
+            const testLendToken = new LendToken({lendTokenId: testLendTokenId});
+            const actualSymbol = await tickerFromCurrency(testLendToken);
             expect(actualSymbol).toBe(fakeLendToken.ticker);
         });
 

--- a/src/mappings/_utils.test.ts
+++ b/src/mappings/_utils.test.ts
@@ -1,14 +1,18 @@
 import { ForeignAsset as LibForeignAsset } from "@interlay/interbtc-api";
-import { cacheForeignAssets, getForeignAsset, symbolFromCurrency, testHelpers } from "./_utils";
-import { ForeignAsset, NativeToken, Token } from "../model";
+import { cacheForeignAssets, cacheLendTokens, getForeignAsset, getLendToken, tickerFromCurrency, testHelpers } from "./_utils";
+import { ForeignAsset, LendToken, NativeToken, Token } from "../model";
 
-// mocking getForeignAsset and getForeignAssets in the lib (interBtcApi)
+// mocking getForeignAsset, getForeignAssets, getLendTokens in the lib (interBtcApi)
 const libGetForeignAssetsMock = jest.fn();
 const libGetForeignAssetMock = jest.fn();
+const libGetLendTokensMock = jest.fn();
 const mockInterBtcApi = {
     assetRegistry: {
         getForeignAssets: () => libGetForeignAssetsMock(),
         getForeignAsset: (id: number) => libGetForeignAssetMock(id)
+    },
+    loans: {
+        getLendTokens: () => libGetLendTokensMock()
     }
 };
 
@@ -35,6 +39,16 @@ describe("_utils", () => {
         ticker:"FOO",
         decimals: 7
     };
+
+    // fake asset to play with
+    const fakeLendToken = {
+        lendToken: {
+            id: 42,
+        },
+        name: "FooCoin lend token",
+        ticker:"qFOO",
+        decimals: 7
+    };    
 
     afterAll(() => {
         jest.resetAllMocks();
@@ -180,10 +194,85 @@ describe("_utils", () => {
         });
     });
 
-    describe("symbolFromCurrency", () => {
+    describe("getLendToken", () => {
+        beforeEach(() => {
+            // clean out cache
+            testHelpers.getLendTokensCache().clear();
+        });
+
+        afterEach(() => {
+            libGetLendTokensMock.mockReset();
+            getInterBtcApiMock.mockReset();
+        });
+
+        it("should fetch value from cache first", async () => {
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+
+            // relies on cache to have been passed as reference
+            testHelpers.getLendTokensCache().set(fakeLendToken.lendToken.id, fakeLendToken);
+
+            const actualLendToken = await getLendToken(fakeLendToken.lendToken.id);
+            expect(actualLendToken).toBe(fakeLendToken);
+            expect(getInterBtcApiMock).not.toHaveBeenCalled();
+            expect(libGetLendTokensMock).not.toHaveBeenCalled();
+        });
+
+        it("should call caching method and return if not found in cache already", async () => {
+            const fakeLibLendTokens = [fakeLendToken];
+            libGetLendTokensMock.mockImplementation(() => Promise.resolve(fakeLibLendTokens));
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+
+            const actualLendToken = await getLendToken(fakeLendToken.lendToken.id);
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetLendTokensMock).toHaveBeenCalledTimes(1);
+
+            expect(actualLendToken).toBe(fakeLendToken);
+        });
+    });
+
+    describe("cacheLendTokens", () => {
+        afterEach(() => {
+            libGetLendTokensMock.mockReset();
+            getInterBtcApiMock.mockReset();
+            testHelpers.getLendTokensCache().clear();
+        });
+
+        it("should get all lend tokens from lib as expected", async () => {
+            const fakeLendTokens = [fakeLendToken];
+            libGetLendTokensMock.mockImplementation(() => Promise.resolve(fakeLendTokens));
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+    
+            await cacheLendTokens();
+            const actualCache = testHelpers.getLendTokensCache();
+    
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetLendTokensMock).toHaveBeenCalledTimes(1);
+            expect(actualCache.has(fakeLendToken.lendToken.id)).toBe(true);
+            expect(actualCache.get(fakeLendToken.lendToken.id)).toBe(fakeLendToken);
+        });
+
+        it("should reject if getInterBtcApi rejects", async () => {
+            getInterBtcApiMock.mockImplementation(() => Promise.reject(Error("yeah nah")));
+
+            await expect(getLendToken(fakeLendToken.lendToken.id)).rejects.toThrow("yeah nah");
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetLendTokensMock).not.toHaveBeenCalled();
+        });
+
+        it("should reject if loans.getLendTokens rejects", async () => {
+            getInterBtcApiMock.mockImplementation(() => Promise.resolve(mockInterBtcApi));
+            libGetLendTokensMock.mockImplementation(() => Promise.reject(Error("who dis")));
+
+            await expect(getLendToken(fakeLendToken.lendToken.id)).rejects.toThrow("who dis");
+            expect(getInterBtcApiMock).toHaveBeenCalledTimes(1);
+            expect(libGetLendTokensMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("tickerFromCurrency", () => {
         it("should return token name for native token", async () => {
             const testNativeToken = new NativeToken({token: Token.KINT});
-            const actualSymbol = await symbolFromCurrency(testNativeToken);
+            const actualSymbol = await tickerFromCurrency(testNativeToken);
 
             expect(actualSymbol).toBe(Token.KINT);
         });
@@ -194,8 +283,18 @@ describe("_utils", () => {
             testHelpers.getForeignAssetsCache().set(testAssetId, fakeAsset);
             
             const testForeignAsset = new ForeignAsset({asset: testAssetId});
-            const actualSymbol = await symbolFromCurrency(testForeignAsset);
+            const actualSymbol = await tickerFromCurrency(testForeignAsset);
             expect(actualSymbol).toBe(fakeAsset.ticker);
+        });
+
+        it("should return ticker for lend token", async () => {
+            const testLendTokenId = fakeLendToken.lendToken.id;
+            // prepare cache for lookup
+            testHelpers.getLendTokensCache().set(testLendTokenId, fakeLendToken);
+            
+            const testForeignAsset = new LendToken({lendTokenId: testLendTokenId});
+            const actualSymbol = await tickerFromCurrency(testForeignAsset);
+            expect(actualSymbol).toBe(fakeLendToken.ticker);
         });
 
         it("should return unknown for unhandled currency type", async () => {
@@ -203,7 +302,7 @@ describe("_utils", () => {
                 isTypeOf: "definitely not a valid type"
             };
 
-            const actualSymbol = await symbolFromCurrency(badTestCurrency as any);
+            const actualSymbol = await tickerFromCurrency(badTestCurrency as any);
             expect(actualSymbol).toBe("UNKNOWN");
         });
 

--- a/src/mappings/event/loans.ts
+++ b/src/mappings/event/loans.ts
@@ -47,7 +47,7 @@ import {
     friendlyAmount,
     getExchangeRate,
     getFirstAndLastFour,
-    symbolFromCurrency,
+    tickerFromCurrency,
     truncateTimestampToDate
 } from "../_utils";
 import { address, currencyId, currencyToString, rateModel } from "../encoding";
@@ -132,7 +132,7 @@ export async function newMarket(
         liquidateIncentive: divideByTenToTheNth(market.liquidateIncentive, FIXEDI128_SCALING_FACTOR),
         liquidationThreshold: market.liquidationThreshold / PERMILL_BASE,
         liquidateIncentiveReservedFactor: market.liquidateIncentiveReservedFactor / PERMILL_BASE,
-        currencySymbol: await symbolFromCurrency(currency)
+        currencySymbol: await tickerFromCurrency(currency)
     });
     // console.log(JSON.stringify(my_market));
     await entityBuffer.pushEntity(LoanMarket.name, my_market);
@@ -182,7 +182,7 @@ export async function updatedMarket(
         liquidateIncentive: divideByTenToTheNth(market.liquidateIncentive, decimals),
         liquidationThreshold: market.liquidationThreshold / PERMILL_BASE,
         liquidateIncentiveReservedFactor: market.liquidateIncentiveReservedFactor / PERMILL_BASE,
-        currencySymbol: await symbolFromCurrency(currency)
+        currencySymbol: await tickerFromCurrency(currency)
     });
 
     switch(market.state.__kind){
@@ -284,7 +284,7 @@ export async function borrow(
             amountBorrowedUsdt: amounts.usdt.toNumber(),
             amountBorrowedBtc: amounts.btc.toNumber(),
             comment: comment,
-            currencySymbol: await symbolFromCurrency(currency)
+            currencySymbol: await tickerFromCurrency(currency)
 
         })
     );
@@ -319,7 +319,7 @@ export async function depositCollateral(
     let symbol;
     if(currency.isTypeOf==='LendToken'){
         const newCurrency = await lendTokenDetails(ctx, currency.lendTokenId);
-        symbol = await symbolFromCurrency(newCurrency);
+        symbol = await tickerFromCurrency(newCurrency);
         const qRate = cachedRates.getRate(block.height, symbol);
 
         const newAmount = Big(amount.toString()).mul(qRate.rate);
@@ -329,7 +329,7 @@ export async function depositCollateral(
             comment = `${getFirstAndLastFour(account)} deposited ${await friendlyAmount(newCurrency, newAmount)} for collateral`
         }
     } else {
-        symbol = await symbolFromCurrency(currency);
+        symbol = await tickerFromCurrency(currency);
         amounts = await getExchangeRate(ctx, block.timestamp, currency, amount.toString());
         comment = `${getFirstAndLastFour(account)} deposited ${await friendlyAmount(currency, amount.toString())} for collateral`
     }
@@ -382,7 +382,7 @@ export async function withdrawCollateral(
     let symbol;
     if(currency.isTypeOf==='LendToken'){
         const newCurrency = await lendTokenDetails(ctx, currency.lendTokenId)
-        symbol = await symbolFromCurrency(newCurrency);
+        symbol = await tickerFromCurrency(newCurrency);
         const qRate = cachedRates.getRate(block.height, symbol);
 
         const newAmount = Big(amount.toString()).mul(qRate.rate);
@@ -392,7 +392,7 @@ export async function withdrawCollateral(
             comment = `${getFirstAndLastFour(account)} withdrew ${await friendlyAmount(newCurrency, newAmount)} from collateral`
         }
     } else {
-        symbol = await symbolFromCurrency(currency);
+        symbol = await tickerFromCurrency(currency);
         amounts = await getExchangeRate(ctx, block.timestamp, currency, amount.toString());
         comment = `${getFirstAndLastFour(account)} withdrew ${await friendlyAmount(currency, amount.toString())} from collateral`
     }
@@ -437,7 +437,7 @@ export async function depositForLending(
         return;
     }
     const currency = currencyId.encode(myCurrencyId);
-    const symbol = await symbolFromCurrency(currency);
+    const symbol = await tickerFromCurrency(currency);
     const height = await blockToHeight(ctx, block.height, "Deposit");
     const account = address.parachain.encode(accountId);
     const amounts = await getExchangeRate(ctx, block.timestamp, currency, amount.toString());
@@ -520,7 +520,7 @@ export async function repay(
             amountRepaidUsdt: amounts.usdt.toNumber(),
             amountRepaidBtc: amounts.btc.toNumber(),
             comment: comment,
-            currencySymbol: await symbolFromCurrency(currency)
+            currencySymbol: await tickerFromCurrency(currency)
         })
     );
 }
@@ -546,7 +546,7 @@ export async function withdrawDeposit(
         return;
     }
     const currency = currencyId.encode(myCurrencyId);
-    const symbol = await symbolFromCurrency(currency);
+    const symbol = await tickerFromCurrency(currency);
     const height = await blockToHeight(ctx, block.height, "Redeemed");
     const account = address.parachain.encode(accountId);
     const amounts = await getExchangeRate(ctx, block.timestamp, currency, amount.toString());
@@ -566,7 +566,7 @@ export async function withdrawDeposit(
             amountWithdrawnUsdt: amounts.usdt.toNumber(),
             amountWithdrawnBtc: amounts.btc.toNumber(),
             comment: comment,
-            currencySymbol: await symbolFromCurrency(currency)
+            currencySymbol: await tickerFromCurrency(currency)
         })
     );
 }
@@ -654,7 +654,7 @@ export async function accrueInterest(
 
     const currency = currencyId.encode(interestAccrued.underlyingCurrencyId);
     const height = await blockToHeight(ctx, block.height, "Interest Accrued");
-    const symbol = await symbolFromCurrency(currency);
+    const symbol = await tickerFromCurrency(currency);
     const decimals = await decimalsFromCurrency(currency);
     cachedRates.addRate(
         block.height,

--- a/src/mappings/utils/pools.ts
+++ b/src/mappings/utils/pools.ts
@@ -272,8 +272,13 @@ export async function buildNewSwapEntity(
 
     const ccyPair = inferGeneralPoolId(swapDetails.from.currency, swapDetails.to.currency);
 
+    const entityPoolId = PoolType.Standard ? ccyPair : String(poolId!);
+
     const entity = new Swap({
-        id: `swap_${ccyPair}_${eventId}`,
+        id: `swap_${entityPoolId}_${eventId}`,
+        poolType,
+        poolId: entityPoolId,
+        eventId,
         height,
         timestamp: blockTimestamp,
         fromAccount: swapDetails.from.accountId,

--- a/src/model/generated/swap.model.ts
+++ b/src/model/generated/swap.model.ts
@@ -29,6 +29,7 @@ export class Swap {
     @ManyToOne_(() => Height, {nullable: true})
     height!: Height
 
+    @Index_()
     @Column_("timestamp with time zone", {nullable: false})
     timestamp!: Date
 

--- a/src/model/generated/swap.model.ts
+++ b/src/model/generated/swap.model.ts
@@ -1,6 +1,7 @@
 import {BigDecimal} from "@subsquid/big-decimal"
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_} from "typeorm"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, Index as Index_, ManyToOne as ManyToOne_} from "typeorm"
 import * as marshal from "./marshal"
+import {PoolType} from "./_poolType"
 import {Height} from "./height.model"
 import {PooledAmount} from "./_pooledAmount"
 
@@ -14,6 +15,17 @@ export class Swap {
     id!: string
 
     @Index_()
+    @Column_("varchar", {length: 8, nullable: false})
+    poolType!: PoolType
+
+    @Index_()
+    @Column_("text", {nullable: false})
+    poolId!: string
+
+    @Column_("text", {nullable: false})
+    eventId!: string
+
+    @Index_()
     @ManyToOne_(() => Height, {nullable: true})
     height!: Height
 
@@ -24,6 +36,7 @@ export class Swap {
     @Column_("text", {nullable: false})
     fromAccount!: string
 
+    @Index_()
     @Column_("text", {nullable: false})
     toAccount!: string
 

--- a/src/server-extension/resolvers/dexVolumesResolver.test.ts
+++ b/src/server-extension/resolvers/dexVolumesResolver.test.ts
@@ -1,83 +1,14 @@
 import { BigDecimal } from "@subsquid/big-decimal";
 import { NativeToken, PooledAmount, Swap, Token } from "../../model";
+import * as mapping_utils from "../../mappings/_utils";
 import {
     testHelpers,
     DexVolumesResolver,
-    DexVolumesByPoolArgs
+    DexVolumesByPoolArgs,
+    DexAmount
 } from "./dexVolumesResolver";
 
-
-describe("DexVolumes resolver helper functions", () => {
-    describe("accumulateDexVolumeSums", () => {
-        it("sums up in/out amounts as expected", () => {
-            const dotToken = new NativeToken({ token: Token.DOT });
-            const ibtcToken = new NativeToken({ token: Token.IBTC });
-
-            const dotAmount = 3800n;
-            const ibtcAmount = 1n;
-    
-            const swap1 = new Swap({
-                from: new PooledAmount({
-                    token: dotToken,
-                    amount: dotAmount
-                }),
-                to: new PooledAmount({
-                    token: ibtcToken,
-                    amount: ibtcAmount,
-                })
-            });
-    
-            // clone and change around to/from
-            const swap2 = Object.assign(new Swap(), swap1);
-            const tmp = swap2.from;
-            swap2.from = swap2.to;
-            swap2.to = tmp;
-
-            const actualSums = testHelpers.accumulateDexVolumeSums(
-                dotToken,
-                ibtcToken,
-                [swap1, swap2]
-            );
-
-            expect(actualSums).toEqual({
-                token1: {
-                    token: dotToken,
-                    in: dotAmount,
-                    out: dotAmount // because we mirrored in/out trades
-                },
-                token2: {
-                    token: ibtcToken,
-                    in: ibtcAmount,
-                    out: ibtcAmount // because we mirrored in/out swaps
-                }
-            });
-
-            // if we use 2x swap1 (DOT in, IBTC out) expect sums to reflect that
-            const actualSums2 = testHelpers.accumulateDexVolumeSums(
-                dotToken,
-                ibtcToken,
-                [swap1, swap1]
-            );
-            
-            expect(actualSums2).toEqual({
-                token1: {
-                    token: dotToken,
-                    in: dotAmount * 2n, // we added 2x swap1 with DOT in
-                    out: 0n
-                },
-                token2: {
-                    token: ibtcToken,
-                    in: 0n,
-                    out: ibtcAmount * 2n // we added 2x swap1 with IBTC in
-                }
-            });
-        });
-    });
-
-    // TODO
-    describe.skip("buildNewDexVolumesPair", () => {});
-});
-
+// tests for the custom resolver arguments class
 describe("DexVolumesByPoolArgs", () => {
     describe("getTokenJson", () => {
         it("should resolve native tokens as expected", () => {
@@ -148,9 +79,310 @@ describe("DexVolumesByPoolArgs", () => {
     });
 });
 
-// todo: add tests
-describe.skip("DexVolumesResolver", () => {
-    describe("getGeneralDexTradingVolumesByPool", () => {
+describe("DexVolumesResolver", () => {
+    const dotToken = new NativeToken({ token: Token.DOT });
+    const ibtcToken = new NativeToken({ token: Token.IBTC });
+    const dotAmount = 3800n;
+    const ibtcAmount = 1n;
+
+    let swapDOTinIBTCout: Swap;
+    let swapIBTCinDOTout: Swap;
+
+    beforeEach(() => {
+        swapDOTinIBTCout = new Swap({
+            from: new PooledAmount({
+                token: dotToken,
+                amount: dotAmount
+            }),
+            to: new PooledAmount({
+                token: ibtcToken,
+                amount: ibtcAmount,
+            })
+        });
+
+        // clone and change around to/from
+        swapIBTCinDOTout = Object.assign(new Swap(), swapDOTinIBTCout);
+        const tmp = swapIBTCinDOTout.from;
+        swapIBTCinDOTout.from = swapIBTCinDOTout.to;
+        swapIBTCinDOTout.to = tmp;
     });
 
+    describe("accumulateDexVolumeSums", () => {
+        it("sums up in/out amounts as expected", () => {
+            const actualSums = testHelpers.accumulateDexVolumeSums(
+                dotToken,
+                ibtcToken,
+                [swapDOTinIBTCout, swapIBTCinDOTout]
+            );
+
+            expect(actualSums).toEqual({
+                token1: {
+                    token: dotToken,
+                    in: dotAmount,
+                    out: dotAmount // because we mirrored in/out trades
+                },
+                token2: {
+                    token: ibtcToken,
+                    in: ibtcAmount,
+                    out: ibtcAmount // because we mirrored in/out swaps
+                }
+            });
+
+            // if we use 2x swap1 (DOT in, IBTC out) expect sums to reflect that
+            const actualSums2 = testHelpers.accumulateDexVolumeSums(
+                dotToken,
+                ibtcToken,
+                [swapDOTinIBTCout, swapDOTinIBTCout]
+            );
+            
+            expect(actualSums2).toEqual({
+                token1: {
+                    token: dotToken,
+                    in: dotAmount * 2n, // we added 2x swap1 with DOT in
+                    out: 0n
+                },
+                token2: {
+                    token: ibtcToken,
+                    in: 0n,
+                    out: ibtcAmount * 2n // we added 2x swap1 with IBTC in
+                }
+            });
+        });
+    });
+    
+    describe("buildNewDexVolumesPair", () => {
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        it("should convert from DexVolumeSums to DexPoolVolumePairs format as expected", async () => {
+            // starts with something like [{token1in, token1out}, {token2in, token2out}]
+            // and should convert to [{token1in, token2in}, {token1out, token2out}] with human amounts
+
+            // mock tickerFromCurrency, return token string if it is a token, "FOO" otherwise
+            jest.spyOn(mapping_utils, "tickerFromCurrency").mockImplementation((currency) => Promise.resolve((currency as any).token || "FOO"));
+            // mock convertToHuman to simply return 0
+            jest.spyOn(mapping_utils, "convertAmountToHuman").mockImplementation((_currency, amount) => Promise.resolve(BigDecimal(0)));
+
+            const fakeDotAmounts = {
+                token: dotToken,
+                in: dotAmount + 42n,
+                out: dotAmount
+            };
+
+            const fakeIbtcAmounts = {
+                token: ibtcToken,
+                in: ibtcAmount,
+                out: ibtcAmount + 1n
+            };
+
+            const testInputSums = {
+                token1: fakeDotAmounts,
+                token2: fakeIbtcAmounts
+            };
+
+            const actualDexVolumesPair = await testHelpers.buildNewDexVolumesPair(testInputSums);
+
+            // build expected output format from fake inputs manually
+            const expectedIbtcIn = new DexAmount({
+                ticker: ibtcToken.token,
+                amount: fakeIbtcAmounts.in,
+                amountHuman: BigDecimal(0) // mocked away
+            });
+
+            const expectedIbtcOut = new DexAmount({
+                ticker: ibtcToken.token,
+                amount: fakeIbtcAmounts.out,
+                amountHuman: BigDecimal(0) // mocked away
+            });
+
+            const expectedDotIn = new DexAmount({
+                ticker: dotToken.token,
+                amount: fakeDotAmounts.in,
+                amountHuman: BigDecimal(0) // mocked away
+            });
+
+            const expectedDotOut = new DexAmount({
+                ticker: dotToken.token,
+                amount: fakeDotAmounts.out,
+                amountHuman: BigDecimal(0) // mocked away
+            });
+
+            expect(actualDexVolumesPair).toEqual({
+                in: [expectedDotIn, expectedIbtcIn],
+                out: [expectedDotOut, expectedIbtcOut]
+            });
+        });
+    });
+    
+    // todo: add tests
+    describe("getGeneralDexTradingVolumesByPool", () => {
+        // helper method to create dummy tx manager method to feed into constructor
+        const mockTxManager = (mockSwaps: Swap[]) => () => Promise.resolve({
+            getRepository: () => ({
+                findBy: () => { return mockSwaps; }
+            })
+        } as any);
+
+        beforeEach(() => {
+            // mock tickerFromCurrency, return token string if it is a token, "FOO" otherwise
+            jest.spyOn(mapping_utils, "tickerFromCurrency").mockImplementation((currency) => Promise.resolve((currency as any).token || "FOO"));
+            // mock convertToHuman to simply return original amount
+            jest.spyOn(mapping_utils, "convertAmountToHuman").mockImplementation((_currency, amount) => Promise.resolve(BigDecimal(amount)));
+
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        it("should return volumes as expected", async () => {
+            // mock so it only returns one swap, from DOT to IBTC
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([swapDOTinIBTCout]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+
+            const actualVolumesByPool = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+
+            expect(actualVolumesByPool.poolId).toEqual("(DOT,IBTC)");
+            expect(actualVolumesByPool.volumesIn.length).toEqual(2);
+            expect(actualVolumesByPool.volumesOut.length).toEqual(2);
+
+            // volumes in checks
+            const volIn0 = actualVolumesByPool.volumesIn[0]
+            // first volume in is for DOT (because it resolves before IBTC)
+            expect(volIn0.ticker).toEqual("DOT");
+            // first amount is the same as first swap (because no other swaps were added)
+            expect(volIn0.amount).toEqual(swapDOTinIBTCout.from.amount);
+            // second amount in is zero (no IBTC amount in for given swap)
+            expect(actualVolumesByPool.volumesIn[1].amount).toEqual(0n);
+
+            // volumes out checks
+            const volOut1 = actualVolumesByPool.volumesOut[1]; // expect IBTC values here
+            expect(volOut1.ticker).toEqual("IBTC");
+            expect(volOut1.amount).toEqual(swapDOTinIBTCout.to.amount);
+            // second out amount is zero, no DOT went out in given swap
+            expect(actualVolumesByPool.volumesOut[0].amount).toEqual(0n);
+        });
+
+        it("should return zero volumes for each ticker in & out if no swaps found", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+
+            const actualVolumesByPool = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+
+            expect(actualVolumesByPool.poolId).toEqual("(DOT,IBTC)");
+            expect(actualVolumesByPool.volumesIn.length).toEqual(2);
+            expect(actualVolumesByPool.volumesOut.length).toEqual(2);
+
+            // collect just amounts from all volumes in and out
+            const allAmounts = [...actualVolumesByPool.volumesIn, ...actualVolumesByPool.volumesOut].map((vol) => vol.amount);
+            expect(allAmounts).toEqual([0n, 0n, 0n, 0n]);
+        });
+
+        it("should treat first and second token params interchangeably", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+
+            const argsReversed = new DexVolumesByPoolArgs();
+            // swap DOT/IBTC around
+            argsReversed.token1 = args.token2;
+            argsReversed.token2 = args.token1;
+            
+            const actualResults = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+            const actualResultsReversedArgs = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(argsReversed);
+
+            // it should show the same inferred pool id
+            expect(actualResults.poolId).toEqual(actualResultsReversedArgs.poolId);
+
+            // but it should respect the token argument order, ie. show first token used in args first in list of volumes
+            expect(actualResults.volumesIn[0].ticker).toEqual(args.token1);
+            expect(actualResults.volumesOut[0].ticker).toEqual(args.token1);
+            expect(actualResultsReversedArgs.volumesIn[0].ticker).toEqual(argsReversed.token1);
+            expect(actualResultsReversedArgs.volumesOut[0].ticker).toEqual(argsReversed.token1);
+        });
+
+        it("should default endDate to new Date() if not provided", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+
+            const dateBeforeCall = new Date();
+            const actualVolumesByPool = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+            
+            // compare unix seconds, so can be equal
+            expect(actualVolumesByPool.endDate.getTime()).toBeGreaterThanOrEqual(dateBeforeCall.getTime());
+        });
+
+        it("should keep endDate value if passed in", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+            args.endDate = new Date("2023-01-01T00:00:00Z");
+
+            const actualVolumesByPool = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+            
+            expect(actualVolumesByPool.endDate.getTime()).toEqual(args.endDate.getTime());
+        });
+
+        it("should default startDate to 7 days before endDate", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+            args.endDate = new Date("2023-01-08T00:00:00Z");
+
+            const expectedStartDate = new Date("2023-01-01T00:00:00Z");
+            const actualVolumesByPool = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+            
+            // compare unix seconds, so can be equal
+            expect(actualVolumesByPool.startDate.getTime()).toEqual(expectedStartDate.getTime());
+        });
+
+        it("should keep startDate value if passed in", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const args = new DexVolumesByPoolArgs();
+            args.token1 = "DOT";
+            args.token2 = "IBTC";
+            args.startDate = new Date("2023-01-01T00:00:00Z");
+            args.endDate = new Date("2023-01-08T00:00:00Z");
+
+            const actualVolumesByPool = await dexVolumeResolver.getGeneralDexTradingVolumesByPool(args);
+            
+            expect(actualVolumesByPool.startDate.getTime()).toEqual(args.startDate.getTime());
+        });
+
+        it("should throw if no first or second currency/token is provided", async () => {
+            // mock no swaps returned from tx manager
+            const dexVolumeResolver = new DexVolumesResolver(mockTxManager([]));
+
+            const argsNo1st = new DexVolumesByPoolArgs();
+            argsNo1st.token2 = "IBTC";
+            await expect(dexVolumeResolver.getGeneralDexTradingVolumesByPool(argsNo1st)).rejects.toThrow(Error);
+
+            const argsNo2nd = new DexVolumesByPoolArgs();
+            argsNo2nd.token1 = "DOT";
+            await expect(dexVolumeResolver.getGeneralDexTradingVolumesByPool(argsNo2nd)).rejects.toThrow(Error);
+        });
+    });
 });

--- a/src/server-extension/resolvers/dexVolumesResolver.test.ts
+++ b/src/server-extension/resolvers/dexVolumesResolver.test.ts
@@ -1,0 +1,156 @@
+import { BigDecimal } from "@subsquid/big-decimal";
+import { NativeToken, PooledAmount, Swap, Token } from "../../model";
+import {
+    testHelpers,
+    DexVolumesResolver,
+    DexVolumesByPoolArgs
+} from "./dexVolumesResolver";
+
+
+describe("DexVolumes resolver helper functions", () => {
+    describe("accumulateDexVolumeSums", () => {
+        it("sums up in/out amounts as expected", () => {
+            const dotToken = new NativeToken({ token: Token.DOT });
+            const ibtcToken = new NativeToken({ token: Token.IBTC });
+
+            const dotAmount = 3800n;
+            const ibtcAmount = 1n;
+    
+            const swap1 = new Swap({
+                from: new PooledAmount({
+                    token: dotToken,
+                    amount: dotAmount
+                }),
+                to: new PooledAmount({
+                    token: ibtcToken,
+                    amount: ibtcAmount,
+                })
+            });
+    
+            // clone and change around to/from
+            const swap2 = Object.assign(new Swap(), swap1);
+            const tmp = swap2.from;
+            swap2.from = swap2.to;
+            swap2.to = tmp;
+
+            const actualSums = testHelpers.accumulateDexVolumeSums(
+                dotToken,
+                ibtcToken,
+                [swap1, swap2]
+            );
+
+            expect(actualSums).toEqual({
+                token1: {
+                    token: dotToken,
+                    in: dotAmount,
+                    out: dotAmount // because we mirrored in/out trades
+                },
+                token2: {
+                    token: ibtcToken,
+                    in: ibtcAmount,
+                    out: ibtcAmount // because we mirrored in/out swaps
+                }
+            });
+
+            // if we use 2x swap1 (DOT in, IBTC out) expect sums to reflect that
+            const actualSums2 = testHelpers.accumulateDexVolumeSums(
+                dotToken,
+                ibtcToken,
+                [swap1, swap1]
+            );
+            
+            expect(actualSums2).toEqual({
+                token1: {
+                    token: dotToken,
+                    in: dotAmount * 2n, // we added 2x swap1 with DOT in
+                    out: 0n
+                },
+                token2: {
+                    token: ibtcToken,
+                    in: 0n,
+                    out: ibtcAmount * 2n // we added 2x swap1 with IBTC in
+                }
+            });
+        });
+    });
+
+    // TODO
+    describe.skip("buildNewDexVolumesPair", () => {});
+});
+
+describe("DexVolumesByPoolArgs", () => {
+    describe("getTokenJson", () => {
+        it("should resolve native tokens as expected", () => {
+            const testTokensArgs = new DexVolumesByPoolArgs();
+            const fakeToken1 = "FOO";
+            const fakeToken2 = "BAR";
+            const expectedType = "NativeToken";
+
+            testTokensArgs.token1 = fakeToken1;
+            testTokensArgs.token2 = fakeToken2;
+
+            expect(testTokensArgs.token1Json).toEqual({
+                isTypeOf: expectedType,
+                token: fakeToken1
+            });
+
+            expect(testTokensArgs.token2Json).toEqual({
+                isTypeOf: expectedType,
+                token: fakeToken2
+            });
+        });
+
+        it("should resolve foreign assets as expected", () => {
+            const testAssetArgs = new DexVolumesByPoolArgs();
+            const fakeAsset1 = 42;
+            const fakeAsset2 = 1;
+            const expectedType = "ForeignAsset";
+            testAssetArgs.assetId1 = fakeAsset1;
+            testAssetArgs.assetId2 = fakeAsset2;
+
+            expect(testAssetArgs.token1Json).toEqual({
+                isTypeOf: expectedType,
+                asset: fakeAsset1
+            });
+
+            expect(testAssetArgs.token2Json).toEqual({
+                isTypeOf: expectedType,
+                asset: fakeAsset2
+            });
+        });
+
+        it("should resolve lend tokens as expected", () => {
+            const testLendTokensArgs = new DexVolumesByPoolArgs();
+            const fakeLendToken1 = 2;
+            const fakeLendToken2 = 7;
+            const expectedType = "LendToken";
+            testLendTokensArgs.lendTokenId1 = fakeLendToken1;
+            testLendTokensArgs.lendTokenId2 = fakeLendToken2;
+
+            expect(testLendTokensArgs.token1Json).toEqual({
+                isTypeOf: expectedType,
+                lendTokenId: fakeLendToken1
+            });
+
+            expect(testLendTokensArgs.token2Json).toEqual({
+                isTypeOf: expectedType,
+                lendTokenId: fakeLendToken2
+            });
+        });
+
+        it("should throw if no token, foreign asset id, or lend token id is set", () => {
+            const brokenArgs = new DexVolumesByPoolArgs();
+            // no tokens, foreign asset ids, or lend token ids set
+
+            expect(() => brokenArgs.token1Json).toThrow(Error);
+            expect(() => brokenArgs.token2Json).toThrow(Error);
+        });
+    });
+});
+
+// todo: add tests
+describe.skip("DexVolumesResolver", () => {
+    describe("getGeneralDexTradingVolumesByPool", () => {
+    });
+
+});

--- a/src/server-extension/resolvers/dexVolumesResolver.ts
+++ b/src/server-extension/resolvers/dexVolumesResolver.ts
@@ -212,7 +212,7 @@ class DexVolumesByPoolArgs {
 
     @Field(() => Int, {
         nullable: true,
-        description: "(optional) pool id value (if the first currency of the pair is a pool.)"
+        description: "(optional) stable pool id value (if the first currency of the pair is a stable pool.)"
     })
     @IsOptional()
     poolId1?: number;
@@ -269,7 +269,7 @@ class DexVolumesByPoolArgs {
 
     @Field(() => Int, {
         nullable: true,
-        description: "(optional) pool id value (if the second currency of the pair is a pool.)"
+        description: "(optional) stable pool id value (if the second currency of the pair is a stable pool.)"
     })
     @IsOptional()
     poolId2?: number;

--- a/src/server-extension/resolvers/dexVolumesResolver.ts
+++ b/src/server-extension/resolvers/dexVolumesResolver.ts
@@ -175,27 +175,45 @@ type PooledTokenInputFields = {
 
 @ArgsType()
 class DexVolumesByPoolArgs {
-    @Field(() => Date, { nullable: true })
+    @Field(() => Date, {
+        nullable: true,
+        description: "(optional) startDate in iso 8061 format. Defaults to 1 week before endDate."
+    })
     @IsOptional()
     startDate?: Date;
 
-    @Field(() => Date, { nullable: true })
+    @Field(() => Date, {
+        nullable: true,
+        description: "(optional) endDate in ISO 8061 format. Defaults to current date/time."
+    })
     @IsOptional()
     endDate?: Date;
 
-    @Field(() => String, { nullable: true })
+    @Field(() => String, {
+        nullable: true,
+        description: "(optional) native token identifier (if the first currency of the pair is a native token.)"
+    })
     @IsOptional()
     token1?: string;
 
-    @Field(() => Int, { nullable: true })
+    @Field(() => Int, {
+        nullable: true,
+        description: "(optional) asset id value (if the first currency of the pair is a foreign asset.)"
+    })
     @IsOptional()
     assetId1?: number;
 
-    @Field(() => Int, { nullable: true })
+    @Field(() => Int, {
+        nullable: true,
+        description: "(optional) lend token id value (if the first currency of the pair is a lend token.)"
+    })
     @IsOptional()
     lendTokenId1?: number;
 
-    @Field(() => Int, { nullable: true })
+    @Field(() => Int, {
+        nullable: true,
+        description: "(optional) pool id value (if the first currency of the pair is a pool.)"
+    })
     @IsOptional()
     poolId1?: number;
 
@@ -228,19 +246,31 @@ class DexVolumesByPoolArgs {
         };
     }
 
-    @Field(() => String, { nullable: true })
+    @Field(() => String, {
+        nullable: true,
+        description: "(optional) native token identifier (if the second currency of the pair is a native token.)"
+    })
     @IsOptional()
     token2?: string;
 
-    @Field(() => Int, { nullable: true })
+    @Field(() => Int, {
+        nullable: true,
+        description: "(optional) asset id value (if the second currency of the pair is a foreign asset.)"
+    })
     @IsOptional()
     assetId2?: number;
 
-    @Field(() => Int, { nullable: true })
+    @Field(() => Int, {
+        nullable: true,
+        description: "(optional) lend token id value (if the second currency of the pair is a lend token.)"
+    })
     @IsOptional()
     lendTokenId2?: number;
 
-    @Field(() => Int, { nullable: true })
+    @Field(() => Int, {
+        nullable: true,
+        description: "(optional) pool id value (if the second currency of the pair is a pool.)"
+    })
     @IsOptional()
     poolId2?: number;
 
@@ -270,7 +300,11 @@ class DexVolumesByPoolArgs {
 export class DexVolumesResolver {
   constructor(private tx: () => Promise<EntityManager>) {}
 
-  @Query(() => DexTradingVolumesByPool)
+  @Query(() => DexTradingVolumesByPool, {
+    description: "Fetch trading volumes for a general dex by currency pairs, start and end date.\n"
+        + "Needs exactly one of token1, assetId1, lendTokenId1, or poolId1 defined for the first currency in the pairing.\n"
+        + "Needs exactly one of token2, assetId2, lendTokenId2, or poolId2 defined for the second currency in the pairing.\n"
+  })
   async getGeneralDexTradingVolumesByPool(
     @Args()
     { startDate, endDate, token1Json, token2Json }: DexVolumesByPoolArgs,

--- a/src/server-extension/resolvers/dexVolumesResolver.ts
+++ b/src/server-extension/resolvers/dexVolumesResolver.ts
@@ -1,0 +1,319 @@
+import { BigDecimal } from '@subsquid/big-decimal';
+import { Arg, Args, ArgsType, Field, Int, ObjectType, Query, Resolver } from 'type-graphql';
+import { type EntityManager, Between } from 'typeorm';
+import { PoolType, PooledAmount, PooledToken, Swap, Token, fromJsonPooledToken } from '../../model';
+import { inferGeneralPoolId } from '../../mappings/utils/pools';
+import { isEqual } from 'lodash';
+import { convertAmountToHuman, tickerFromCurrency } from '../../mappings/_utils';
+import { IsOptional } from 'class-validator';
+
+@ObjectType()
+export class DexAmount {
+    constructor(props?: Partial<DexAmount>) {
+        Object.assign(this, props)
+    }
+
+    @Field(() => String, {nullable: false})
+    ticker!: string;
+
+    @Field(() => BigInt, {nullable: false})
+    amount!: bigint;
+
+    @Field(() => BigDecimal, {nullable: false})
+    amountHuman!: BigDecimal;
+}
+
+@ObjectType()
+export class DexTradingVolumesByPool {
+    constructor(props?: Partial<DexTradingVolumesByPool>) {
+        Object.assign(this, props)
+    }
+
+    @Field(() => String, {nullable: false})
+    poolId!: string;
+  
+    @Field(() => String, {nullable: false})
+    poolType!: string;
+
+    @Field(() => Date, {nullable: false})
+    startDate!: Date;
+
+    @Field(() => Date, {nullable: false})
+    endDate!: Date;
+
+    @Field(() => [DexAmount], {nullable: false})
+    volumesIn!: DexAmount[];
+
+    @Field(() => [DexAmount], {nullable: false})
+    volumesOut!: DexAmount[];
+}
+
+type TokenWithAmounts = {
+    token: PooledToken,
+    in: bigint,
+    out: bigint,
+}
+
+type DexVolumeSums = {
+    token1: TokenWithAmounts,
+    token2: TokenWithAmounts,
+};
+
+// in/out volumes for token1/token2 respectively
+type DexPoolVolumesPair = { in: [DexAmount, DexAmount], out: [DexAmount, DexAmount] };
+
+const buildTokenInOutVolumes = async (
+    tokenAmounts: TokenWithAmounts
+): Promise<{in: DexAmount, out: DexAmount}> => {
+    const { token, in: amountIn, out: amountOut } = tokenAmounts;
+    const ticker = await tickerFromCurrency(token);
+
+    const [ amountHumanIn, amountHumanOut ] = await Promise.all([
+        convertAmountToHuman(token, amountIn),
+        convertAmountToHuman(token, amountOut)
+    ]);
+
+    return {
+        in: new DexAmount({
+            ticker,
+            amount: amountIn,
+            amountHuman: amountHumanIn
+        }),
+        out: new DexAmount({
+            ticker,
+            amount: amountOut,
+            amountHuman: amountHumanOut
+        })
+    };
+}
+
+const buildNewDexVolumesPair = async (
+    sums: DexVolumeSums
+): Promise<DexPoolVolumesPair> => {
+    const [
+        {in: t1In, out: t1Out},
+        {in: t2In, out: t2Out}
+    ] = await Promise.all([
+        buildTokenInOutVolumes(sums.token1),
+        buildTokenInOutVolumes(sums.token2)
+    ]);
+
+    return { in: [t1In, t2In],  out: [t1Out, t2Out] };
+}
+
+const queryEntityManagerForDexGeneralSwaps = async (
+    tx: () => Promise<EntityManager>,
+    poolId: string,
+    startDate: Date,
+    endDate: Date
+): Promise<Swap[]> => {
+    const manager = await tx();
+
+    return await manager.getRepository(Swap)
+        .findBy({
+            poolType: PoolType.Standard,
+            poolId,
+            timestamp: Between(startDate, endDate)
+        });
+};
+
+// assumes all swaps are between two specific tokens (ie. not a multi-ccy pool, just swap pairs)
+const accumulateDexVolumeSums = (
+    token1: PooledToken,
+    token2: PooledToken,
+    swaps: Swap[],
+): DexVolumeSums => {
+    const isToken1 = (token: PooledToken) => isEqual(token1, token);
+
+    const startingValue: DexVolumeSums = {
+        token1: {
+            token: token1,
+            in: 0n,
+            out: 0n,
+        },
+        token2: {
+            token: token2,
+            in: 0n,
+            out: 0n,
+        },
+    };
+
+    return swaps.reduce((acc, swapEntity) => {
+        const tokenIn = swapEntity.from.token;
+        const amountIn = swapEntity.from.amount;
+        const amountOut = swapEntity.to.amount;
+
+        if(isToken1(tokenIn)) {
+            acc.token1.in += amountIn;
+            acc.token2.out += amountOut;
+        } else {
+            acc.token2.in += amountIn;
+            acc.token1.out += amountOut;
+        }
+
+        return acc;
+    }, startingValue);
+}
+
+/**
+ * Testhelper export for better testing/mocking, use at your own risk
+ */
+export const testHelpers = {
+    accumulateTokenPairInOutAmounts: accumulateDexVolumeSums,
+    queryEntityManagerForDexGeneralSwaps,
+    buildVolumesInOut: buildNewDexVolumesPair,
+};
+
+// input structure that's compatible with the fromJsonPooledToken method
+type PooledTokenInputFields = {
+    isTypeOf: string,
+    token?: string,
+    asset?: number,
+    lendTokenId?: number,
+    poolId?: number,
+}
+
+@ArgsType()
+class DexVolumesByPoolArgs {
+    @Field(() => Date, { nullable: true })
+    @IsOptional()
+    startDate?: Date;
+
+    @Field(() => Date, { nullable: true })
+    @IsOptional()
+    endDate?: Date;
+
+    @Field(() => String, { nullable: true })
+    @IsOptional()
+    token1?: string;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    assetId1?: number;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    lendTokenId1?: number;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    poolId1?: number;
+
+    // helper to identify which token type the optional inputs represent
+    private _findType(input: Partial<PooledTokenInputFields>): string | undefined {
+        return (input.token != null) ? "NativeToken"
+        : (input.asset != null) ? "ForeignAsset"
+        : (input.lendTokenId != null) ? "LendToken"
+        : (input.poolId != null) ? "StableLpToken"
+        : undefined
+    }
+
+    get token1Json(): PooledTokenInputFields {
+        const input: Partial<PooledTokenInputFields> = {
+            token: this.token1,
+            asset: this.assetId1,
+            lendTokenId: this.lendTokenId1,
+            poolId: this.poolId1
+        };
+        const type = this._findType(input);
+
+        if(type === undefined) {
+            throw Error("Unable to detect token/currency type for the given parameters, " 
+                + "please make sure that one of the fields (token1, assetId1, lendTokenId1, poolId1) is set");
+        }
+
+        return {
+            isTypeOf: type,
+            ...input
+        };
+    }
+
+    @Field(() => String, { nullable: true })
+    @IsOptional()
+    token2?: string;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    assetId2?: number;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    lendTokenId2?: number;
+
+    @Field(() => Int, { nullable: true })
+    @IsOptional()
+    poolId2?: number;
+
+    get token2Json(): PooledTokenInputFields {
+        const input: Partial<PooledTokenInputFields> = {
+            token: this.token2,
+            asset: this.assetId2,
+            lendTokenId: this.lendTokenId2,
+            poolId: this.poolId2
+        };
+
+        const type = this._findType(input);
+
+        if(type === undefined) {
+            throw Error("Unable to detect token/currency type for the given parameters, " 
+                + "please make sure that one of the fields (token2, assetId2, lendTokenId2, poolId2) is set");
+        }
+
+        return {
+            isTypeOf: type,
+            ...input
+        };
+    }
+}
+
+@Resolver()
+export class DexVolumesResolver {
+  constructor(private tx: () => Promise<EntityManager>) {}
+
+  @Query(() => DexTradingVolumesByPool)
+  async getGeneralDexTradingVolumesByPool(
+    @Args()
+    { startDate, endDate, token1Json, token2Json }: DexVolumesByPoolArgs,
+  ): Promise<DexTradingVolumesByPool> {
+
+    // convert from input to internal & output type
+    const currency1 = fromJsonPooledToken(token1Json);
+    const currency2 = fromJsonPooledToken(token2Json);
+
+    const generalPoolId = inferGeneralPoolId(currency1, currency2);
+
+    // default to now if not set
+    if (!endDate) {
+        endDate = new Date();
+    }
+
+    // default to end date minus 7 days if not set
+    if (!startDate) {
+        // clone end date
+        startDate = new Date(endDate);
+        // mutate start date
+        startDate.setDate(startDate.getDate() - 7);
+    }
+
+    const swapsList = await queryEntityManagerForDexGeneralSwaps(
+        this.tx,
+        generalPoolId,
+        startDate,
+        endDate,
+    );
+
+    const sums = accumulateDexVolumeSums(currency1, currency2, swapsList);
+    const volumes = await buildNewDexVolumesPair(sums);
+
+    const dexTradingVolumes = new DexTradingVolumesByPool({
+        poolId: generalPoolId,
+        poolType: PoolType.Standard,
+        startDate,
+        endDate,
+        volumesIn: volumes.in,
+        volumesOut: volumes.out,
+    });
+
+    return dexTradingVolumes;
+  }
+}

--- a/src/server-extension/resolvers/index.ts
+++ b/src/server-extension/resolvers/index.ts
@@ -1,1 +1,2 @@
+export { DexAmount, DexTradingVolumesByPool, DexVolumesResolver } from "./dexVolumesResolver";
 export { AccountLoanDeposits, AccountLoanDepositsResolver as AccountLoanDepositResolver } from "./loanDepositsResolver";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,6 +2251,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/validator@^13.7.10":
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.11.1.tgz#6560af76ed54490e68c42f717ab4e742ba7be74b"
+  integrity sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A==
+
 "@types/vinyl@^2.0.4":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.7.tgz#9739a9a2afaf9af32761c54a0e82c735279f726c"
@@ -3188,6 +3193,15 @@ cjs-module-lexer@^1.0.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
+
+class-validator@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.14.0.tgz#40ed0ecf3c83b2a8a6a320f4edb607be0f0df159"
+  integrity sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==
+  dependencies:
+    "@types/validator" "^13.7.10"
+    libphonenumber-js "^1.10.14"
+    validator "^13.7.0"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -5697,6 +5711,11 @@ leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+libphonenumber-js@^1.10.14:
+  version "1.10.40"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.40.tgz#537695176bc6e5c650f26492526fc622d879b1fd"
+  integrity sha512-dWL0lV8Q+wr4XE4LxYG1Qr86kdfElCqXgGj9bm0HxOOGpvw4GEJeQxuiHyqCCXDxBctSQBfxM8HljiWf3INkMA==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -8250,6 +8269,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==
   dependencies:
     builtins "^1.0.3"
+
+validator@^13.7.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
 
 value-or-promise@1.0.11:
   version "1.0.11"


### PR DESCRIPTION
Resolves #123 

Get separate in/out volumes for swaps, as opposed to a grand total cumulative value only.

Added this as a custom resolver `getGeneralDexTradingVolumesByPool` since squid has all swap data stored. So, no need to update totals for each swap event.
Keeping the "old" `cumulativeDexTradingVolumePerPools` entity which does not separate in/out volumes for the time being in order to avoid introducing a breaking change for the UI team / dashboards using it.

TODO before ready for review:
- [x] add tests for the new resolver
- [x] run full scan of kintsugi to check that numbers make sense
- [x] run full scan of interlay